### PR TITLE
投稿された内容を一時的に保存・表示させる　機能追加

### DIFF
--- a/lib/posts-handler.js
+++ b/lib/posts-handler.js
@@ -1,5 +1,6 @@
 'use strict';
 const jade = require('jade');
+const contents = [];
 
 function handle(req, res) {
   switch (req.method) {
@@ -18,6 +19,8 @@ function handle(req, res) {
         const decoded = decodeURIComponent(body);
         const content = decoded.split('content=')[1];
         console.info('投稿されました: ' + content);
+        contents.push('[' + new Date().toString() + ']' + content);
+        console.info('今までに投稿された内容: ' + contents);
         handleRedirectPosts(req, res);
       });
       break;


### PR DESCRIPTION
テストですので、マージは不要です。

### 変更点
- サーバーが立ってる間に投稿された内容の一時保存
- サーバーが立ってる間に投稿された内容出力
- 投稿内容保存時に時刻の追加